### PR TITLE
Add posts API filter for tags

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -20,6 +20,7 @@ return function (Dispatcher $events) {
     $events->subscribe(Listener\AddTagsApi::class);
     $events->subscribe(Listener\CreatePostWhenTagsAreChanged::class);
     $events->subscribe(Listener\FilterDiscussionListByTags::class);
+    $events->subscribe(Listener\FilterPostsQueryByTags::class);
     $events->subscribe(Listener\SaveTagsToDatabase::class);
     $events->subscribe(Listener\UpdateTagMetadata::class);
 

--- a/src/Listener/FilterPostsQueryByTag.php
+++ b/src/Listener/FilterPostsQueryByTag.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Tags\Listener;
+
+use Flarum\Event\ConfigurePostsQuery;
+use Illuminate\Contracts\Events\Dispatcher;
+
+class FilterPostsQueryByTag
+{
+    /**
+     * @param Dispatcher $events
+     */
+    public function subscribe(Dispatcher $events)
+    {
+        $events->listen(ConfigurePostsQuery::class, [$this, 'filterQuery']);
+    }
+
+    /**
+     * @param ConfigurePostsQuery $event
+     */
+    public function filterQuery(ConfigurePostsQuery $event)
+    {
+        if ($tagId = array_get($event->filter, 'tag')) {
+            $event->query
+                ->join('discussions_tags', 'discussions_tags.discussion_id', '=', 'posts.discussion_id')
+                ->where('discussions_tags.tag_id', $tagId);
+        }
+    }
+}


### PR DESCRIPTION
Add the means of filtering post queries by the tags of the posts' parent discussions. See https://github.com/flarum/core/issues/990.