### PR TITLE
Fix Internal Server Error for blank API requests

### DIFF
--- a/src/Api/Controller/CreateTagController.php
+++ b/src/Api/Controller/CreateTagController.php
@@ -44,7 +44,7 @@ class CreateTagController extends AbstractCreateController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         return $this->bus->dispatch(
-            new CreateTag($request->getAttribute('actor'), array_get($request->getParsedBody(), 'data'))
+            new CreateTag($request->getAttribute('actor'), array_get($request->getParsedBody(), 'data', []))
         );
     }
 }

--- a/src/Api/Controller/UpdateTagController.php
+++ b/src/Api/Controller/UpdateTagController.php
@@ -45,7 +45,7 @@ class UpdateTagController extends AbstractResourceController
     {
         $id = array_get($request->getQueryParams(), 'id');
         $actor = $request->getAttribute('actor');
-        $data = array_get($request->getParsedBody(), 'data');
+        $data = array_get($request->getParsedBody(), 'data', []);
 
         return $this->bus->dispatch(
             new EditTag($id, $actor, $data)


### PR DESCRIPTION
Attempting to send an empty body to the create and update endpoints will result in Flarum outputting "Internal Server Error" as plain text, instead of failing gracefully with a json-ised validation exception.

This adds an empty array as the third parameter to `array_get()`, which sets the default value and thus allows Flarum to do its thing.

Response before this change:
![2017-04-06-042354](https://cloud.githubusercontent.com/assets/1521802/24736594/c57cf03a-1a80-11e7-92a5-11cd9d99b5fd.png)

Response after applying fix:
![2017-04-06-042354](https://cloud.githubusercontent.com/assets/1521802/24736625/e7cf12f8-1a80-11e7-9eb4-07efcadad075.png)
