### PR TITLE
Specify available includes for /api/tags endpoint

### DIFF
--- a/src/Api/Controller/ListTagsController.php
+++ b/src/Api/Controller/ListTagsController.php
@@ -25,6 +25,20 @@ class ListTagsController extends AbstractCollectionController
     public $serializer = TagSerializer::class;
 
     /**
+     * {@inheritdoc}
+     */
+    public $include = [
+        'parent',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public $optionalInclude = [
+        'lastDiscussion',
+    ];
+
+    /**
      * @var \Flarum\Tags\Tag
      */
     protected $tags;


### PR DESCRIPTION
Currently the list endpoint doesn't return the parent relation, making it difficult to work with child tags. Attempts to add `?include=parent` to the URL return an empty `errors=[]` response.

With this PR, `/api/tags` will include a child tag's parent under `relationships`.
Appending `?include=parent,lastDiscussion` will also include the latest discussion.