### PR TITLE
Enable parent to be set during creation via API

### DIFF
--- a/src/Api/Controller/CreateTagController.php
+++ b/src/Api/Controller/CreateTagController.php
@@ -26,6 +26,11 @@ class CreateTagController extends AbstractCreateController
     public $serializer = TagSerializer::class;
 
     /**
+     * {@inheritdoc}
+     */
+    public $include = ['parent'];
+
+    /**
      * @var Dispatcher
      */
     protected $bus;

--- a/src/Command/CreateTagHandler.php
+++ b/src/Command/CreateTagHandler.php
@@ -51,6 +51,17 @@ class CreateTagHandler
             array_get($data, 'attributes.isHidden')
         );
 
+        if ($parentId = array_get($data, 'relationships.parent.data.id')) {
+            $rootTags = Tag::whereNull('parent_id')->whereNotNull('position');
+
+            if ($rootTags->find($parentId)) {
+                $position = Tag::where('parent_id', $parentId)->max('position');
+
+                $tag->parent()->associate($parentId);
+                $tag->position = $position === null ? 0 : $position + 1;
+            }
+        }
+
         $this->validator->assertValid($tag->getAttributes());
 
         $tag->save();

--- a/src/Command/CreateTagHandler.php
+++ b/src/Command/CreateTagHandler.php
@@ -51,10 +51,14 @@ class CreateTagHandler
             array_get($data, 'attributes.isHidden')
         );
 
-        if ($parentId = array_get($data, 'relationships.parent.data.id')) {
+        $parentId = array_get($data, 'relationships.parent.data.id');
+
+        if ($parentId !== null) {
             $rootTags = Tag::whereNull('parent_id')->whereNotNull('position');
 
-            if ($rootTags->find($parentId)) {
+            if ($parentId === 0) {
+                $tag->position = $rootTags->max('position') + 1;
+            } elseif ($rootTags->find($parentId)) {
                 $position = Tag::where('parent_id', $parentId)->max('position');
 
                 $tag->parent()->associate($parentId);


### PR DESCRIPTION
Sets the parent ID as long as it exists and is a top-level primary tag.
If it's not, it'll simply be ignored. Position is set automatically to be one higher than the current highest, or 0 if parent has no children.

Example data (in addition to the usual attributes):
```
"relationships": {
    "parent": {
        "data": {
            "id": 1
        }
    }
}
```