### PR TITLE
Lazy-load any included relationships on /api/tags

### DIFF
--- a/src/Api/Controller/ListTagsController.php
+++ b/src/Api/Controller/ListTagsController.php
@@ -57,7 +57,10 @@ class ListTagsController extends AbstractCollectionController
     protected function data(ServerRequestInterface $request, Document $document)
     {
         $actor = $request->getAttribute('actor');
+        $include = $this->extractInclude($request);
 
-        return $this->tags->whereVisibleTo($actor)->withStateFor($actor)->get();
+        $tags = $this->tags->whereVisibleTo($actor)->withStateFor($actor)->get();
+
+        return $tags->load($include);
     }
 }


### PR DESCRIPTION
Adds eager-loading to the tags list API as per discussion in #38 