### PR TITLE
Show modal if # of primary/secondary tags is less than required

### DIFF
--- a/js/forum/dist/extension.js
+++ b/js/forum/dist/extension.js
@@ -49,13 +49,16 @@ System.register('flarum/tags/addTagComposer', ['flarum/extend', 'flarum/componen
     override(DiscussionComposer.prototype, 'onsubmit', function (original) {
       var _this2 = this;
 
-      if (!this.tags.length || !this.tags.filter(function (tag) {
+      var chosenTags = this.tags;
+      var chosenPrimaryTags = chosenTags.filter(function (tag) {
         return tag.position() !== null && !tag.isChild();
-      }).length < app.forum.attribute('minPrimaryTags') || !this.tags.filter(function (tag) {
+      });
+      var chosenSecondaryTags = chosenTags.filter(function (tag) {
         return tag.position() === null;
-      }).length < app.forum.attribute('minSecondaryTags')) {
+      });
+      if (!chosenTags.length || chosenPrimaryTags.length < app.forum.attribute('minPrimaryTags') || chosenSecondaryTags.length < app.forum.attribute('minSecondaryTags')) {
         app.modal.show(new TagDiscussionModal({
-          selectedTags: this.tags,
+          selectedTags: chosenTags,
           onsubmit: function onsubmit(tags) {
             _this2.tags = tags;
             original();

--- a/js/forum/dist/extension.js
+++ b/js/forum/dist/extension.js
@@ -10,13 +10,11 @@ System.register('flarum/tags/addTagComposer', ['flarum/extend', 'flarum/componen
       var tag = app.store.getBy('tags', 'slug', this.params().tags);
 
       if (tag) {
-        (function () {
-          var parent = tag.parent();
-          var tags = parent ? [parent, tag] : [tag];
-          promise.then(function (component) {
-            return component.tags = tags;
-          });
-        })();
+        var parent = tag.parent();
+        var tags = parent ? [parent, tag] : [tag];
+        promise.then(function (component) {
+          return component.tags = tags;
+        });
       }
     });
 
@@ -51,9 +49,13 @@ System.register('flarum/tags/addTagComposer', ['flarum/extend', 'flarum/componen
     override(DiscussionComposer.prototype, 'onsubmit', function (original) {
       var _this2 = this;
 
-      if (!this.tags.length) {
+      if (!this.tags.length || !this.tags.filter(function (tag) {
+        return tag.position() !== null && !tag.isChild();
+      }).length < app.forum.attribute('minPrimaryTags') || !this.tags.filter(function (tag) {
+        return tag.position() === null || tag.isChild();
+      }).length < app.forum.attribute('minSecondaryTags')) {
         app.modal.show(new TagDiscussionModal({
-          selectedTags: [],
+          selectedTags: this.tags,
           onsubmit: function onsubmit(tags) {
             _this2.tags = tags;
             original();

--- a/js/forum/dist/extension.js
+++ b/js/forum/dist/extension.js
@@ -52,7 +52,7 @@ System.register('flarum/tags/addTagComposer', ['flarum/extend', 'flarum/componen
       if (!this.tags.length || !this.tags.filter(function (tag) {
         return tag.position() !== null && !tag.isChild();
       }).length < app.forum.attribute('minPrimaryTags') || !this.tags.filter(function (tag) {
-        return tag.position() === null || tag.isChild();
+        return tag.position() === null;
       }).length < app.forum.attribute('minSecondaryTags')) {
         app.modal.show(new TagDiscussionModal({
           selectedTags: this.tags,

--- a/js/forum/src/addTagComposer.js
+++ b/js/forum/src/addTagComposer.js
@@ -45,7 +45,7 @@ export default function() {
   override(DiscussionComposer.prototype, 'onsubmit', function(original) {
     if (!this.tags.length
       || (!this.tags.filter(tag => tag.position() !== null && !tag.isChild()).length < app.forum.attribute('minPrimaryTags'))
-      || (!this.tags.filter(tag => tag.position() === null || tag.isChild()).length < app.forum.attribute('minSecondaryTags'))) {
+      || (!this.tags.filter(tag => tag.position() === null).length < app.forum.attribute('minSecondaryTags'))) {
       app.modal.show(
         new TagDiscussionModal({
           selectedTags: this.tags,

--- a/js/forum/src/addTagComposer.js
+++ b/js/forum/src/addTagComposer.js
@@ -43,10 +43,12 @@ export default function() {
   });
 
   override(DiscussionComposer.prototype, 'onsubmit', function(original) {
-    if (!this.tags.length) {
+    if (!this.tags.length
+      || (!this.tags.filter(tag => tag.position() !== null && !tag.isChild()).length < app.forum.attribute('minPrimaryTags'))
+      || (!this.tags.filter(tag => tag.position() === null || tag.isChild()).length < app.forum.attribute('minSecondaryTags'))) {
       app.modal.show(
         new TagDiscussionModal({
-          selectedTags: [],
+          selectedTags: this.tags,
           onsubmit: tags => {
             this.tags = tags;
             original();

--- a/js/forum/src/addTagComposer.js
+++ b/js/forum/src/addTagComposer.js
@@ -43,12 +43,15 @@ export default function() {
   });
 
   override(DiscussionComposer.prototype, 'onsubmit', function(original) {
-    if (!this.tags.length
-      || (!this.tags.filter(tag => tag.position() !== null && !tag.isChild()).length < app.forum.attribute('minPrimaryTags'))
-      || (!this.tags.filter(tag => tag.position() === null).length < app.forum.attribute('minSecondaryTags'))) {
+    const chosenTags = this.tags;
+    const chosenPrimaryTags = chosenTags.filter(tag => tag.position() !== null && !tag.isChild());
+    const chosenSecondaryTags = chosenTags.filter(tag => tag.position() === null);
+    if (!chosenTags.length
+      || (chosenPrimaryTags.length < app.forum.attribute('minPrimaryTags'))
+      || (chosenSecondaryTags.length < app.forum.attribute('minSecondaryTags'))) {
       app.modal.show(
         new TagDiscussionModal({
-          selectedTags: this.tags,
+          selectedTags: chosenTags,
           onsubmit: tags => {
             this.tags = tags;
             original();

--- a/src/Listener/UpdateTagMetadata.php
+++ b/src/Listener/UpdateTagMetadata.php
@@ -11,7 +11,6 @@
 
 namespace Flarum\Tags\Listener;
 
-use Flarum\Core\Post;
 use Flarum\Event\DiscussionWasDeleted;
 use Flarum\Event\DiscussionWasStarted;
 use Flarum\Event\PostWasDeleted;


### PR DESCRIPTION
Shows a modal if the number of primary or secondary tags is less than the number specified in settings.
I've gotten the filter for the primary and secondary tags from `js/admin/src/TagsPage.js` ([L60](https://github.com/flarum/flarum-ext-tags/blob/master/js/admin/src/components/TagsPage.js#L60), [L69](https://github.com/flarum/flarum-ext-tags/blob/master/js/admin/src/components/TagsPage.js#L69))
Fixes flarum/core#1101. Please squash ^_^

### Changelog
- [Fixed] Errored if num of primary/secondary tags is less than required