### PR TITLE
Use page component for tags page

### DIFF
--- a/js/forum/src/components/TagsPage.js
+++ b/js/forum/src/components/TagsPage.js
@@ -1,4 +1,4 @@
-import Component from 'flarum/Component';
+import Page from 'flarum/components/Page';
 import IndexPage from 'flarum/components/IndexPage';
 import listItems from 'flarum/helpers/listItems';
 import humanTime from 'flarum/helpers/humanTime';
@@ -7,14 +7,13 @@ import icon from 'flarum/helpers/icon';
 import tagLabel from 'flarum/tags/helpers/tagLabel';
 import sortTags from 'flarum/tags/utils/sortTags';
 
-export default class TagsPage extends Component {
+export default class TagsPage extends Page {
   init() {
+    super.init();
+
     this.tags = sortTags(app.store.all('tags').filter(tag => !tag.parent()));
 
-    app.current = this;
     app.history.push('tags', icon('fas fa-th-large'));
-    app.drawer.hide();
-    app.modal.close();
   }
 
   view() {

--- a/js/forum/src/components/TagsPage.js
+++ b/js/forum/src/components/TagsPage.js
@@ -75,14 +75,10 @@ export default class TagsPage extends Component {
 
             {cloud.length ? (
               <div className="TagCloud">
-                {cloud.map(tag => {
-                  const color = tag.color();
-
-                  return [
-                    tagLabel(tag, {link: true}),
-                    ' '
-                  ];
-                })}
+                {cloud.map(tag => [
+                  tagLabel(tag, {link: true}),
+                  ' ',
+                ])}
               </div>
             ) : ''}
           </div>

--- a/js/forum/src/components/TagsPage.js
+++ b/js/forum/src/components/TagsPage.js
@@ -2,7 +2,6 @@ import Page from 'flarum/components/Page';
 import IndexPage from 'flarum/components/IndexPage';
 import listItems from 'flarum/helpers/listItems';
 import humanTime from 'flarum/helpers/humanTime';
-import icon from 'flarum/helpers/icon';
 
 import tagLabel from 'flarum/tags/helpers/tagLabel';
 import sortTags from 'flarum/tags/utils/sortTags';
@@ -13,7 +12,7 @@ export default class TagsPage extends Page {
 
     this.tags = sortTags(app.store.all('tags').filter(tag => !tag.parent()));
 
-    app.history.push('tags', icon('fas fa-th-large'));
+    app.history.push('tags', app.translator.trans('flarum-tags.forum.header.back_to_tags_tooltip'));
   }
 
   view() {


### PR DESCRIPTION
For some mysterious reasons the tags page wasn't using the Page component before.

I also fixed the history stack that was messed up when loading the tags page (icon passed as the title, resulting in `[Object object]` as the title of the back button...

This PR requires the new translation added in https://github.com/flarum/flarum-ext-english/pull/123