### PR TITLE
Replacement of fa-large with fa-tags for future redesign

### DIFF
--- a/js/src/forum/addTagList.js
+++ b/js/src/forum/addTagList.js
@@ -12,7 +12,7 @@ export default function() {
   // to the index page's sidebar.
   extend(IndexPage.prototype, 'navItems', function(items) {
     items.add('tags', LinkButton.component({
-      icon: 'fas fa-th-large',
+      icon: 'fas fa-tags',
       children: app.translator.trans('flarum-tags.forum.index.tags_link'),
       href: app.route('tags')
     }), -10);


### PR DESCRIPTION
As we're going to see a redesign on the tags page, it would be better to see a replacement of the th-large icon with the tags icon for it to represent the page better and be general.

https://fontawesome.com/icons/tags?style=solid