### PR TITLE
Add support for "own" permissions

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -11,9 +11,11 @@
 
 use Flarum\Extend;
 use Flarum\Forum\Controller\FrontendController;
+use Flarum\Group\Group;
 use Flarum\Tags\Access;
 use Flarum\Tags\Api\Controller;
 use Flarum\Tags\Listener;
+use Flarum\User\User;
 use Illuminate\Contracts\Events\Dispatcher;
 
 return [
@@ -49,5 +51,7 @@ return [
         $events->subscribe(Access\DiscussionPolicy::class);
         $events->subscribe(Access\TagPolicy::class);
         $events->subscribe(Access\FlagPolicy::class);
+
+        User::$basePermissions['discussion.own.tag'] = [Group::MEMBER_ID];
     },
 ];

--- a/src/Access/DiscussionPolicy.php
+++ b/src/Access/DiscussionPolicy.php
@@ -11,7 +11,6 @@
 
 namespace Flarum\Tags\Access;
 
-use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Tags\Tag;

--- a/src/Access/DiscussionPolicy.php
+++ b/src/Access/DiscussionPolicy.php
@@ -43,10 +43,21 @@ class DiscussionPolicy extends AbstractPolicy
      * @param User $actor
      * @param string $ability
      * @param Discussion $discussion
-     * @return bool
+     * @return bool|void
      */
     public function can(User $actor, $ability, Discussion $discussion)
     {
+        // Permissions for the 'editOwnPosts' ability are not configurable, so
+        // we will respect the global interpretation regardless of what the
+        // discussion's tags are.
+        if ($ability === 'editOwnPosts') {
+            return;
+        }
+
+        if ($actor->id === $discussion->start_user_id && $actor->hasPermission('discussion.own.'.$ability)) {
+            return true;
+        }
+
         // Wrap all discussion permission checks with some logic pertaining to
         // the discussion's tags. If the discussion has a tag that has been
         // restricted, the user must have the permission for that tag.
@@ -123,11 +134,9 @@ class DiscussionPolicy extends AbstractPolicy
         if ($discussion->start_user_id == $actor->id) {
             $allowEditTags = $this->settings->get('allow_tag_change');
 
-            if ($allowEditTags === '-1'
-                || ($allowEditTags === 'reply' && $discussion->participants_count <= 1)
-                || ($discussion->start_time->diffInMinutes(new Carbon) < $allowEditTags)
-            ) {
-                return true;
+            if (($allowEditTags === 'reply' && $discussion->participants_count > 1)
+                || ($allowEditTags !== '-1' && $discussion->start_time->diffInMinutes() > $allowEditTags)) {
+                return false;
             }
         }
     }


### PR DESCRIPTION
Since tags executes its own catch-all permission logic for discussions,
we need to write in a special case for the new "own" permissions which
are not configurable per-tag.

See flarum/core#1512